### PR TITLE
Ajuste para impedir Exception em caso da variável headerCallbackContext estiver vazia

### DIFF
--- a/FPDF.php
+++ b/FPDF.php
@@ -420,7 +420,7 @@ class FPDF
         if (is_callable($this->headerCallback))
         {
             call_user_func( $this->headerCallback, $this->headerCallbackContext ? $this->headerCallbackContext : $this );
-            $this->headerCallbackContext->addRow();
+            $this->headerCallbackContext ? $this->headerCallbackContext->addRow() : null ;
         }
         //To be implemented in your own inherited class
     }


### PR DESCRIPTION
Validar headerCallbackContext antes de chamar addRow(), evitando uma Exceção caso a variável esteja vazia.